### PR TITLE
[#7] Fix missing validation to property types

### DIFF
--- a/src/components/SchemaEditor/types/ArrayEditor.tsx
+++ b/src/components/SchemaEditor/types/ArrayEditor.tsx
@@ -92,6 +92,21 @@ const ArrayEditor: React.FC<TypeEditorProps> = ({
     [validationNode],
   );
 
+  const minItemsError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find(
+        (err) => err.path[0] === "minItems",
+      )?.message,
+    [validationNode],
+  );
+
+  const maxItemsError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find(
+        (err) => err.path[0] === "maxItems",
+      )?.message,
+    [validationNode],
+  );
 
   return (
     <div className="space-y-6">
@@ -100,7 +115,7 @@ const ArrayEditor: React.FC<TypeEditorProps> = ({
         <div className="space-y-2">
           <Label
             htmlFor={minItemsId}
-            className={!!minMaxError && "text-destructive"}
+            className={(!!minMaxError || !!minItemsError) && "text-destructive"}
           >
             {t.arrayMinimumLabel}
           </Label>
@@ -123,7 +138,7 @@ const ArrayEditor: React.FC<TypeEditorProps> = ({
         <div className="space-y-2">
           <Label
             htmlFor={maxItemsId}
-            className={!!minMaxError && "text-destructive"}
+            className={(!!minMaxError || !!maxItemsError) && "text-destructive"}
           >
             {t.arrayMaximumLabel}
           </Label>
@@ -142,10 +157,12 @@ const ArrayEditor: React.FC<TypeEditorProps> = ({
             className={cn("h-8", !!minMaxError && "border-destructive")}
           />
         </div>
-        {!!minMaxError && (
-          <p className="text-xs text-destructive italic md:col-span-2">
-            {minMaxError}
-          </p>
+        {(!!minMaxError || !!minItemsError || !!maxItemsError) && (
+          <div className="text-xs text-destructive italic md:col-span-2 whitespace-pre-line">
+            {[minMaxError, minItemsError ?? maxItemsError]
+              .filter(Boolean)
+              .join("\n")}
+          </div>
         )}
       </div>
 

--- a/src/components/SchemaEditor/types/NumberEditor.tsx
+++ b/src/components/SchemaEditor/types/NumberEditor.tsx
@@ -201,6 +201,14 @@ const NumberEditor: React.FC<NumberEditorProps> = ({
     [validationNode],
   );
 
+  const multipleOfError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find(
+        (err) => err.path[0] === "multipleOf",
+      )?.message,
+    [validationNode],
+  );
+
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -347,7 +355,12 @@ const NumberEditor: React.FC<NumberEditorProps> = ({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={multipleOfId}>{t.numberMultipleOfLabel}</Label>
+        <Label
+          htmlFor={multipleOfId}
+          className={!!multipleOfError && "text-destructive"}
+        >
+          {t.numberMultipleOfLabel}
+        </Label>
         <Input
           id={multipleOfId}
           type="number"
@@ -357,10 +370,15 @@ const NumberEditor: React.FC<NumberEditorProps> = ({
             handleValidationChange("multipleOf", value);
           }}
           placeholder={t.numberMultipleOfPlaceholder}
-          className="h-8"
+          className={cn("h-8", !!multipleOfError && "border-destructive")}
           min={0}
           step={integer ? 1 : "any"}
         />
+        {!!multipleOfError && (
+          <div className="text-xs text-destructive italic whitespace-pre-line">
+            {multipleOfError}
+          </div>
+        )}
       </div>
 
       <div className="space-y-2 pt-2 border-t border-border/40">

--- a/src/components/SchemaEditor/types/StringEditor.tsx
+++ b/src/components/SchemaEditor/types/StringEditor.tsx
@@ -106,13 +106,46 @@ const StringEditor: React.FC<TypeEditorProps> = ({
     [validationNode],
   );
 
+  const minLengthError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find(
+        (err) => err.path[0] === "minLength",
+      )?.message,
+    [validationNode],
+  );
+
+  const maxLengthError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find(
+        (err) => err.path[0] === "maxLength",
+      )?.message,
+    [validationNode],
+  );
+
+  const patternError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find(
+        (err) => err.path[0] === "pattern",
+      )?.message,
+    [validationNode],
+  );
+
+  const formatError = useMemo(
+    () =>
+      validationNode?.validation.errors?.find((err) => err.path[0] === "format")
+        ?.message,
+    [validationNode],
+  );
+
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
         <div className="space-y-2">
           <Label
             htmlFor={minLengthId}
-            className={!!minMaxError && "text-destructive"}
+            className={
+              (!!minMaxError || !!minLengthError) && "text-destructive"
+            }
           >
             {t.stringMinimumLengthLabel}
           </Label>
@@ -126,14 +159,19 @@ const StringEditor: React.FC<TypeEditorProps> = ({
               handleValidationChange("minLength", value);
             }}
             placeholder={t.stringMinimumLengthPlaceholder}
-            className={cn("h-8", !!minMaxError && "border-destructive")}
+            className={cn(
+              "h-8",
+              (!!minMaxError || !!minLengthError) && "border-destructive",
+            )}
           />
         </div>
 
         <div className="space-y-2">
           <Label
             htmlFor={maxLengthId}
-            className={minMaxError && "text-destructive"}
+            className={
+              (!!minMaxError || !!maxLengthError) && "text-destructive"
+            }
           >
             {t.stringMaximumLengthLabel}
           </Label>
@@ -147,18 +185,28 @@ const StringEditor: React.FC<TypeEditorProps> = ({
               handleValidationChange("maxLength", value);
             }}
             placeholder={t.stringMaximumLengthPlaceholder}
-            className={cn("h-8", minMaxError && "border-destructive")}
+            className={cn(
+              "h-8",
+              (!!minMaxError || !!maxLengthError) && "border-destructive",
+            )}
           />
         </div>
-        {minMaxError && (
-          <p className="text-xs text-destructive italic md:col-span-2">
-            {minMaxError}
-          </p>
+        {(!!minMaxError || !!minLengthError || !!maxLengthError) && (
+          <div className="text-xs text-destructive italic md:col-span-2 whitespace-pre-line">
+            {[minMaxError, minLengthError ?? maxLengthError]
+              .filter(Boolean)
+              .join("\n")}
+          </div>
         )}
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={patternId}>{t.stringPatternLabel}</Label>
+        <Label
+          htmlFor={patternId}
+          className={!!patternError && "text-destructive"}
+        >
+          {t.stringPatternLabel}
+        </Label>
         <Input
           id={patternId}
           type="text"
@@ -173,7 +221,12 @@ const StringEditor: React.FC<TypeEditorProps> = ({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={formatId}>{t.stringFormatLabel}</Label>
+        <Label
+          htmlFor={formatId}
+          className={!!formatError && "text-destructive"}
+        >
+          {t.stringFormatLabel}
+        </Label>
         <Select
           value={format || "none"}
           onValueChange={(value) => {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -147,4 +147,8 @@ export const de: Translation = {
 
   visualEditorNoFieldsHint1: "Noch keine Felder definiert",
   visualEditorNoFieldsHint2: "Erstes Feld hinzufügen, um zu starten",
+
+  typeValidationErrorNegativeLength: "Längenwerte dürfen nicht negativ sein.",
+  typeValidationErrorIntValue: "Der Wert muss eine ganze Zahl sein.",
+  typeValidationErrorPositive: "Der Wert muss positiv sein.",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -144,4 +144,8 @@ export const en: Translation = {
 
   visualEditorNoFieldsHint1: "No fields defined yet",
   visualEditorNoFieldsHint2: "Add your first field to get started",
+
+  typeValidationErrorNegativeLength: "Length values cannot be negative.",
+  typeValidationErrorIntValue: "Value must be an integer.",
+  typeValidationErrorPositive: "Value must be positive.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -149,4 +149,9 @@ export const fr: Translation = {
 
   visualEditorNoFieldsHint1: "Aucun champ défini pour le moment",
   visualEditorNoFieldsHint2: "Ajoutez votre premier champ pour commencer",
+
+  typeValidationErrorNegativeLength:
+    "Les valeurs de longueur ne peuvent pas être négatives.",
+  typeValidationErrorIntValue: "La valeur doit être un nombre entier.",
+  typeValidationErrorPositive: "La valeur doit être positive.",
 };

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -148,4 +148,9 @@ export const ru: Translation = {
 
   visualEditorNoFieldsHint1: "Пока не определено ни одного поля",
   visualEditorNoFieldsHint2: "Добавьте ваше первое поле, чтобы начать",
+
+  typeValidationErrorNegativeLength:
+    "Значения длины не могут быть отрицательными.",
+  typeValidationErrorIntValue: "Значение должно быть целым числом.",
+  typeValidationErrorPositive: "Значение должно быть положительным.",
 };

--- a/src/i18n/translation-keys.ts
+++ b/src/i18n/translation-keys.ts
@@ -740,4 +740,23 @@ export interface Translation {
    * > Add your first field to get started
    */
   readonly visualEditorNoFieldsHint2: string;
+
+  /**
+   * The translation for the key `typeValidationErrorNegativeLength`. English default is:
+   *
+   * > Length values cannot be negative.
+   */
+  readonly typeValidationErrorNegativeLength: string;
+  /**
+   * The translation for the key `typeValidationErrorIntValue`. English default is:
+   *
+   * > Value must be an integer.
+   */
+  readonly typeValidationErrorIntValue: string;
+  /**
+   * The translation for the key `typeValidationErrorPositive`. English default is:
+   *
+   * > Value must be positive.
+   */
+  readonly typeValidationErrorPositive: string;
 }

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -23,8 +23,16 @@ function refineRangeConsistency(
 const getJsonStringType = (t: Translation) =>
   z
     .object({
-      minLength: baseSchema.shape.minLength,
-      maxLength: baseSchema.shape.maxLength,
+      minLength: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
+      maxLength: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
       pattern: baseSchema.shape.pattern,
       format: baseSchema.shape.format,
       enum: baseSchema.shape.enum,
@@ -44,7 +52,10 @@ const getJsonStringType = (t: Translation) =>
 const getJsonNumberType = (t: Translation) =>
   z
     .object({
-      multipleOf: baseSchema.shape.multipleOf,
+      multipleOf: z
+        .number()
+        .positive({ message: t.typeValidationErrorPositive })
+        .optional(),
       minimum: baseSchema.shape.minimum,
       maximum: baseSchema.shape.maximum,
       exclusiveMinimum: baseSchema.shape.exclusiveMinimum,
@@ -111,11 +122,27 @@ const getJsonNumberType = (t: Translation) =>
 const getJsonArrayType = (t: Translation) =>
   z
     .object({
-      minItems: baseSchema.shape.minItems,
-      maxItems: baseSchema.shape.maxItems,
-      uniqueItems: baseSchema.shape.uniqueItems,
-      minContains: baseSchema.shape.minContains,
-      maxContains: baseSchema.shape.maxContains,
+      minItems: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
+      maxItems: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
+      uniqueItems: z.boolean().optional(),
+      minContains: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
+      maxContains: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
     })
     // If both minItems and maxItems are set, minItems must not be greater than maxItems.
     .refine(
@@ -139,8 +166,16 @@ const getJsonArrayType = (t: Translation) =>
 const getJsonObjectType = (t: Translation) =>
   z
     .object({
-      minProperties: baseSchema.shape.minProperties,
-      maxProperties: baseSchema.shape.maxProperties,
+      minProperties: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
+      maxProperties: z
+        .number()
+        .int({ message: t.typeValidationErrorIntValue })
+        .min(0, { message: t.typeValidationErrorNegativeLength })
+        .optional(),
     })
     // If both minProperties and maxProperties are set, minProperties must not be greater than maxProperties.
     .refine(


### PR DESCRIPTION
Fixes lovasoa/jsonjoy-builder#7

Some basic property options were not considered in the validation (See <https://github.com/lovasoa/jsonjoy-builder/pull/8#issuecomment-3302016905>)

Changes:

- Added validation error messages for negative length values and non-integer values where applicable (string length, array length, number multipleOf)
- Updated translations for the new messages in de, fr, and ru.
