### PR TITLE
fix: correct inverted behavior of "force unique items" switch

### DIFF
--- a/src/components/SchemaEditor/types/ArrayEditor.tsx
+++ b/src/components/SchemaEditor/types/ArrayEditor.tsx
@@ -56,7 +56,13 @@ const ArrayEditor: React.FC<TypeEditorProps> = ({
     onChange(propsToKeep as ObjectJSONSchema);
   };
 
-  // 构建验证对象的辅助函数，接受 uniqueItems 参数
+  /**
+   * Builds and normalizes the JSON Schema validation properties for an array schema.
+   *
+   * This helper merges base schema constraints with optional overrides,
+   * preserves the `items` schema when not explicitly provided,
+   * and removes any undefined properties to produce a clean schema object.
+  */
   const buildValidationProps = ({
     minItems: overrideMinItems,
     maxItems: overrideMaxItems,


### PR DESCRIPTION
## Summary

This PR fixes an issue where the **"force unique items"** switch behaved incorrectly due to stale state being used during validation.

## Explanation

```ts
// Previously
onCheckedChange={(checked) => {
  setUniqueItems(checked);
  setTimeout(handleValidationChange, 0);
}}
```

`setTimeout` does not guarantee that React state updates are flushed, and `handleValidationChange` was still called with a closure capturing the previous value. 

---

A form-based approach (e.g. `react-hook-form`) could further simplify state management, but is intentionally out of scope for this PR.