### PR TITLE
fix: add missing translations

### DIFF
--- a/src/components/SchemaEditor/JsonSchemaEditor.tsx
+++ b/src/components/SchemaEditor/JsonSchemaEditor.tsx
@@ -98,7 +98,7 @@ const JsonSchemaEditor: FC<JsonSchemaEditorProps> = ({
                 type="button"
                 onClick={toggleFullscreen}
                 className="p-1.5 rounded-md hover:bg-secondary transition-colors"
-                aria-label="Toggle fullscreen"
+                aria-label={t.schemaEditorToggleFullscreen}
               >
                 <Maximize2 size={16} />
               </button>

--- a/src/components/SchemaEditor/TypeEditor.tsx
+++ b/src/components/SchemaEditor/TypeEditor.tsx
@@ -6,6 +6,7 @@ import type {
 } from "../../types/jsonSchema.ts";
 import { withObjectSchema } from "../../types/jsonSchema.ts";
 import type { ValidationTreeNode } from "../../types/validation.ts";
+import { useTranslation } from "../../hooks/use-translation.ts";
 
 // Lazy load specific type editors to avoid circular dependencies
 const StringEditor = lazy(() => import("./types/StringEditor.tsx"));
@@ -29,6 +30,7 @@ const TypeEditor: React.FC<TypeEditorProps> = ({
   depth = 0,
   readOnly = false,
 }) => {
+  const t = useTranslation();
   const type = withObjectSchema(
     schema,
     (s) => (s.type || "object") as SchemaType,
@@ -36,7 +38,7 @@ const TypeEditor: React.FC<TypeEditorProps> = ({
   );
 
   return (
-    <Suspense fallback={<div>Loading editor...</div>}>
+    <Suspense fallback={<div>{t.schemaEditorLoading}</div>}>
       {type === "string" && (
         <StringEditor
           readOnly={readOnly}

--- a/src/components/SchemaEditor/types/BooleanEditor.tsx
+++ b/src/components/SchemaEditor/types/BooleanEditor.tsx
@@ -90,7 +90,7 @@ const BooleanEditor: React.FC<TypeEditorProps> = ({
         <div className="space-y-2 pt-2">
           {(!readOnly || hasEnum) && (
             <>
-              <Label>Allowed Values</Label>
+              <Label>{t.booleanAllowedValuesLabel}</Label>
 
               <div className="space-y-3">
                 <div className="flex items-center space-x-2">

--- a/src/components/SchemaEditor/types/StringEditor.tsx
+++ b/src/components/SchemaEditor/types/StringEditor.tsx
@@ -269,7 +269,7 @@ const StringEditor: React.FC<TypeEditorProps> = ({
             }}
           >
             <SelectTrigger id={formatId} className="h-8">
-              <SelectValue placeholder="Select format" />
+              <SelectValue placeholder={t.stringFormatSelectPlaceholder} />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="none">{t.stringFormatNone}</SelectItem>
@@ -333,7 +333,7 @@ const StringEditor: React.FC<TypeEditorProps> = ({
               onClick={handleAddEnumValue}
               className="px-3 py-1 h-8 rounded-md bg-secondary text-xs font-medium hover:bg-secondary/80"
             >
-              Add
+              {t.stringAllowedValuesEnumAddLabel}
             </button>
           </div>
         </div>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -48,6 +48,7 @@ export const de: Translation = {
   schemaEditorToggleFullscreen: "Vollbild umschalten",
   schemaEditorEditModeVisual: "Visuell",
   schemaEditorEditModeJson: "JSON",
+  schemaEditorLoading: "Editor wird geladen...",
 
   arrayNoConstraint: "Keine Einschränkung",
   arrayMinimumLabel: "Mindestanzahl an Elementen",
@@ -62,6 +63,7 @@ export const de: Translation = {
     "'minContains' darf nicht größer als 'maxContains' sein.",
 
   booleanNoConstraint: "Keine Einschränkung",
+  booleanAllowedValuesLabel: "Erlaubte Werte",
   booleanAllowFalseLabel: "Falsch-Werte erlauben",
   booleanAllowTrueLabel: "Wahr-Werte erlauben",
   booleanNeitherWarning:
@@ -115,6 +117,8 @@ export const de: Translation = {
   stringAllowedValuesEnumLabel: "Erlaubte Werte (Enum)",
   stringAllowedValuesEnumNone: "Keine Einschränkung für Werte festgelegt",
   stringAllowedValuesEnumAddPlaceholder: "Erlaubten Wert hinzufügen...",
+  stringAllowedValuesEnumAddLabel: "Hinzufügen",
+  stringFormatSelectPlaceholder: "Format auswählen",
   stringValidationErrorLengthRange:
     "'Minimale Länge' darf nicht größer als 'Maximale Länge' sein.",
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -47,6 +47,7 @@ export const en: Translation = {
   schemaEditorToggleFullscreen: "Toggle fullscreen",
   schemaEditorEditModeVisual: "Visual",
   schemaEditorEditModeJson: "JSON",
+  schemaEditorLoading: "Loading editor...",
 
   arrayNoConstraint: "No constraint",
   arrayMinimumLabel: "Minimum Items",
@@ -60,6 +61,7 @@ export const en: Translation = {
     "'minContains' cannot be greater than 'maxContains'.",
 
   booleanNoConstraint: "No constraint",
+  booleanAllowedValuesLabel: "Allowed Values",
   booleanAllowFalseLabel: "Allow false value",
   booleanAllowTrueLabel: "Allow true value",
   booleanNeitherWarning: "Warning: You must allow at least one value.",
@@ -112,6 +114,8 @@ export const en: Translation = {
   stringAllowedValuesEnumLabel: "Allowed Values (enum)",
   stringAllowedValuesEnumNone: "No restricted values set",
   stringAllowedValuesEnumAddPlaceholder: "Add allowed value...",
+  stringAllowedValuesEnumAddLabel: "Add",
+  stringFormatSelectPlaceholder: "Select format",
   stringValidationErrorLengthRange:
     "'Minimum Length' cannot be greater than 'Maximum Length'.",
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -48,6 +48,7 @@ export const es: Translation = {
   schemaEditorToggleFullscreen: "Cambiar a pantalla completa",
   schemaEditorEditModeVisual: "Visual",
   schemaEditorEditModeJson: "JSON",
+  schemaEditorLoading: "Cargando editor...",
 
   arrayNoConstraint: "Sin restricción",
   arrayMinimumLabel: "Mínimo de Elementos",
@@ -61,6 +62,7 @@ export const es: Translation = {
     "'minContains' no puede ser mayor que 'maxContains'.",
 
   booleanNoConstraint: "Sin restricción",
+  booleanAllowedValuesLabel: "Valores Permitidos",
   booleanAllowFalseLabel: "Permitir valor falso",
   booleanAllowTrueLabel: "Permitir valor verdadero",
   booleanNeitherWarning: "Advertencia: Debes permitir al menos un valor.",
@@ -114,6 +116,8 @@ export const es: Translation = {
   stringAllowedValuesEnumLabel: "Valores Permitidos (enum)",
   stringAllowedValuesEnumNone: "No hay valores restringidos",
   stringAllowedValuesEnumAddPlaceholder: "Agregar valor permitido...",
+  stringAllowedValuesEnumAddLabel: "Agregar",
+  stringFormatSelectPlaceholder: "Seleccionar formato",
   stringValidationErrorLengthRange:
     "'Longitud Mínima' no puede ser mayor que 'Longitud Máxima'.",
 

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -49,6 +49,7 @@ export const fr: Translation = {
   schemaEditorToggleFullscreen: "Basculer en plein écran",
   schemaEditorEditModeVisual: "Visuel",
   schemaEditorEditModeJson: "JSON",
+  schemaEditorLoading: "Chargement de l'éditeur...",
 
   arrayNoConstraint: "Pas de constrainte",
   arrayMinimumLabel: "Éléments minimum",
@@ -63,6 +64,7 @@ export const fr: Translation = {
     "'minContains' ne peut pas être supérieur à 'maxContains'.",
 
   booleanNoConstraint: "Pas de constrainte",
+  booleanAllowedValuesLabel: "Valeurs autorisées",
   booleanAllowFalseLabel: "Autoriser la valeur faux",
   booleanAllowTrueLabel: "Autoriser la valeur vrai",
   booleanNeitherWarning:
@@ -116,6 +118,8 @@ export const fr: Translation = {
   stringAllowedValuesEnumLabel: "Valeurs autorisées (enum)",
   stringAllowedValuesEnumNone: "Aucune valeur restreinte définie",
   stringAllowedValuesEnumAddPlaceholder: "Ajouter une valeur autorisée...",
+  stringAllowedValuesEnumAddLabel: "Ajouter",
+  stringFormatSelectPlaceholder: "Sélectionner le format",
   stringValidationErrorLengthRange:
     "'Longueur minimale' ne peut pas être supérieure à 'Longueur maximale'.",
 

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -49,6 +49,7 @@ export const ru: Translation = {
   schemaEditorToggleFullscreen: "Переключить полноэкранный режим",
   schemaEditorEditModeVisual: "Визуальный",
   schemaEditorEditModeJson: "JSON",
+  schemaEditorLoading: "Загрузка редактора...",
 
   arrayNoConstraint: "Без ограничений",
   arrayMinimumLabel: "Минимум элементов",
@@ -62,6 +63,7 @@ export const ru: Translation = {
     "'minContains' не может быть больше 'maxContains'.",
 
   booleanNoConstraint: "Без ограничений",
+  booleanAllowedValuesLabel: "Разрешенные значения",
   booleanAllowFalseLabel: "Разрешить значение ложь",
   booleanAllowTrueLabel: "Разрешить значение истина",
   booleanNeitherWarning: "Внимание: Вы должны разрешить хотя бы одно значение.",
@@ -115,6 +117,8 @@ export const ru: Translation = {
   stringAllowedValuesEnumLabel: "Разрешенные значения (enum)",
   stringAllowedValuesEnumNone: "Нет ограниченных значений",
   stringAllowedValuesEnumAddPlaceholder: "Добавить разрешенное значение...",
+  stringAllowedValuesEnumAddLabel: "Добавить",
+  stringFormatSelectPlaceholder: "Выберите формат",
   stringValidationErrorLengthRange:
     "'Минимальная длина' не может быть больше 'Максимальной длины'.",
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -47,6 +47,7 @@ export const zh: Translation = {
   schemaEditorToggleFullscreen: "切换全屏",
   schemaEditorEditModeVisual: "可视化",
   schemaEditorEditModeJson: "JSON",
+  schemaEditorLoading: "正在加载编辑器...",
 
   arrayNoConstraint: "无约束",
   arrayMinimumLabel: "最少子项数",
@@ -60,6 +61,7 @@ export const zh: Translation = {
     "「最少包含子项数」不能大于「最多包含子项数」",
 
   booleanNoConstraint: "无约束",
+  booleanAllowedValuesLabel: "允许的值",
   booleanAllowFalseLabel: "允许值为 false",
   booleanAllowTrueLabel: "允许值为 true",
   booleanNeitherWarning: "警告：你必须允许至少一个值。",
@@ -110,6 +112,8 @@ export const zh: Translation = {
   stringAllowedValuesEnumLabel: "允许的值 (枚举)",
   stringAllowedValuesEnumNone: "当前没有设置限制的值",
   stringAllowedValuesEnumAddPlaceholder: "添加允许的值...",
+  stringAllowedValuesEnumAddLabel: "添加",
+  stringFormatSelectPlaceholder: "选择格式",
   stringValidationErrorLengthRange: "「最小长度」不能大于「最大长度」",
 
   schemaTypeArray: "数组",

--- a/src/i18n/translation-keys.ts
+++ b/src/i18n/translation-keys.ts
@@ -306,6 +306,12 @@ export interface Translation {
    */
   readonly booleanAllowFalseLabel: string;
   /**
+   * The translation for the key `booleanAllowedValuesLabel`. English default is:
+   *
+   * > Allowed Values
+   */
+  readonly booleanAllowedValuesLabel: string;
+  /**
    * The translation for the key `booleanNeitherWarning`. English default is:
    *
    * > Warning: You must allow at least one value.
@@ -567,6 +573,18 @@ export interface Translation {
    */
   readonly stringAllowedValuesEnumAddPlaceholder: string;
   /**
+   * The translation for the key `stringAllowedValuesEnumAddLabel`. English default is:
+   *
+   * > Add
+   */
+  readonly stringAllowedValuesEnumAddLabel: string;
+  /**
+   * The translation for the key `stringFormatSelectPlaceholder`. English default is:
+   *
+   * > Select format
+   */
+  readonly stringFormatSelectPlaceholder: string;
+  /**
    * The translation for the key `stringValidationErrorMinLength`. English default is:
    *
    * > 'minLength' cannot be greater than 'maxLength'.
@@ -634,6 +652,12 @@ export interface Translation {
    * > JSON
    */
   readonly schemaEditorEditModeJson: string;
+  /**
+   * The translation for the key `schemaEditorLoading`. English default is:
+   *
+   * > Loading editor...
+   */
+  readonly schemaEditorLoading: string;
 
   /**
    * The translation for the key `inferrerTitle`. English default is:


### PR DESCRIPTION
This PR aims to add missing translations.
I have noticed that some parts were not translated when using German language and so I looked through the code and found a few places.

The translations for all languages except German and English are provided by AI, so someone might want to check if they are correct.

Thank you for this awesome component.