### PR TITLE
fix: preserve field position when renaming

### DIFF
--- a/src/components/SchemaEditor/SchemaVisualEditor.tsx
+++ b/src/components/SchemaEditor/SchemaVisualEditor.tsx
@@ -4,6 +4,7 @@ import {
   createFieldSchema,
   updateObjectProperty,
   updatePropertyRequired,
+  renameObjectProperty,
 } from "../../lib/schemaEditor.ts";
 import type { JSONSchema, NewField } from "../../types/jsonSchema.ts";
 import { asObjectSchema, isBooleanSchema } from "../../types/jsonSchema.ts";
@@ -50,12 +51,17 @@ const SchemaVisualEditor: FC<SchemaVisualEditorProps> = ({
     // Create a field schema based on the updated field data
     const fieldSchema = createFieldSchema(updatedField);
 
-    // Update the field in the schema
-    let newSchema = updateObjectProperty(
-      asObjectSchema(schema),
-      updatedField.name,
-      fieldSchema,
-    );
+    let newSchema = asObjectSchema(schema);
+
+    // If name changed, rename the property while preserving order
+    if (name !== updatedField.name) {
+      newSchema = renameObjectProperty(newSchema, name, updatedField.name);
+      // Update the field schema after rename
+      newSchema = updateObjectProperty(newSchema, updatedField.name, fieldSchema);
+    } else {
+      // Name didn't change, just update the schema
+      newSchema = updateObjectProperty(newSchema, name, fieldSchema);
+    }
 
     // Update required status
     newSchema = updatePropertyRequired(
@@ -63,29 +69,6 @@ const SchemaVisualEditor: FC<SchemaVisualEditorProps> = ({
       updatedField.name,
       updatedField.required || false,
     );
-
-    // If name changed, we need to remove the old field
-    if (name !== updatedField.name) {
-      const { properties, ...rest } = newSchema;
-      const { [name]: _, ...remainingProps } = properties || {};
-
-      newSchema = {
-        ...rest,
-        properties: remainingProps,
-      };
-
-      // Re-add the field with the new name
-      newSchema = updateObjectProperty(
-        newSchema,
-        updatedField.name,
-        fieldSchema,
-      );
-
-      // Re-update required status if needed
-      if (updatedField.required) {
-        newSchema = updatePropertyRequired(newSchema, updatedField.name, true);
-      }
-    }
 
     // Update the schema
     onChange(newSchema);

--- a/src/lib/schemaEditor.ts
+++ b/src/lib/schemaEditor.ts
@@ -158,6 +158,40 @@ export function getArrayItemsSchema(schema: JSONSchema): JSONSchema | null {
 }
 
 /**
+ * Renames a property while preserving order in the object schema
+ */
+export function renameObjectProperty(
+  schema: ObjectJSONSchema,
+  oldName: string,
+  newName: string,
+): ObjectJSONSchema {
+  if (!isObjectSchema(schema) || !schema.properties) return schema;
+
+  const newSchema = copySchema(schema);
+  const newProperties: Record<string, JSONSchema> = {};
+
+  // Iterate through properties in order, replacing old key with new key
+  for (const [key, value] of Object.entries(newSchema.properties)) {
+    if (key === oldName) {
+      newProperties[newName] = value;
+    } else {
+      newProperties[key] = value;
+    }
+  }
+
+  newSchema.properties = newProperties;
+
+  // Update required array if the field name changed
+  if (newSchema.required) {
+    newSchema.required = newSchema.required.map((field) =>
+      field === oldName ? newName : field,
+    );
+  }
+
+  return newSchema;
+}
+
+/**
  * Checks if a schema has children
  */
 export function hasChildren(schema: JSONSchema): boolean {

--- a/test/lib/schemaEditor.test.ts
+++ b/test/lib/schemaEditor.test.ts
@@ -1,0 +1,23 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { renameObjectProperty } from "../../src/lib/schemaEditor.ts";
+
+describe("renameObjectProperty", () => {
+  test("preserves property order when renaming", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        firstName: { type: "string" as const },
+        lastName: { type: "string" as const },
+        email: { type: "string" as const },
+      },
+      required: ["firstName", "lastName", "email"],
+    };
+
+    const result = renameObjectProperty(schema, "lastName", "surname");
+
+    const keys = Object.keys(result.properties);
+    assert.deepStrictEqual(keys, ["firstName", "surname", "email"]);
+    assert.deepStrictEqual(result.required, ["firstName", "surname", "email"]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the issue where fields would move to the end of the properties list when their names were edited.

## Root Cause
When renaming a field, the old property was being deleted and re-added with the new name, causing it to move to the end of the object.

## Solution
- Extracted field rename logic into a new utility function: `renameObjectProperty()` in `src/lib/schemaEditor.ts`
- This function iterates through properties in order and replaces the old key with the new key, preserving position
- Simplified `handleEditField` in SchemaVisualEditor to use the new utility

## Changes
- **src/lib/schemaEditor.ts**: Added `renameObjectProperty()` utility function
- **src/components/SchemaEditor/SchemaVisualEditor.tsx**: Refactored to use `renameObjectProperty()`
- **test/lib/schemaEditor.test.ts**: Single focused unit test of the actual rename function

## Test Coverage
- ✅ 50 total tests pass (49 existing + 1 new)
- ✅ Build succeeds without errors
- ✅ 4-line test that directly tests `renameObjectProperty()` function

Closes #11