### PR TITLE
Add `autoFocus` prop to `JsonSchemaVisualizer` and `SchemaInferencer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ The built files will be available in the `dist` directory.
 - **SchemaInferencer**: Dialog component for generating schemas from JSON data
 - **JsonValidator**: Dialog component for validating JSON against the current schema
 
+### Component Props
+
+#### `JsonSchemaVisualizer`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `schema` | `JSONSchema` | — | The JSON Schema to display and edit |
+| `className` | `string` | — | Additional CSS class name |
+| `onChange` | `(schema: JSONSchema) => void` | — | Called when the schema is edited |
+| `autoFocus` | `boolean` | `true` | Whether the editor should be focused when mounted |
+
+#### `SchemaInferencer`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | — | Whether the dialog is open |
+| `onOpenChange` | `(open: boolean) => void` | — | Called when the dialog open state changes |
+| `onSchemaInferred` | `(schema: JSONSchema) => void` | — | Called when a schema is generated from JSON input |
+| `autoFocus` | `boolean` | `true` | Whether the editor should be focused when mounted |
+
 ### Key Features
 
 #### Schema Inference

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A modern, React-based visual JSON Schema editor for creating and manipulating JS
 - **Real-time JSON Preview**: See your schema in JSON format as you build it visually
 - **Schema Inference**: Generate schemas automatically from existing JSON data
 - **JSON Validation**: Test JSON data against your schema with detailed validation feedback
+- **Combinator Types**: Full support for `anyOf`, `oneOf`, and `allOf` schema composition
+- **Additional Properties**: Control whether objects allow extra properties beyond the defined ones
 - **Responsive Design**: Fully responsive interface that works on desktop and mobile devices
 
 ## Getting Started
@@ -160,6 +162,10 @@ The `SchemaInferencer` component can automatically generate JSON Schema definiti
 - Numeric types (integers vs. floats)
 - Required fields
 
+#### Combinator Schemas
+
+The editor supports composing schemas with `anyOf`, `oneOf`, and `allOf` combinators. Each combinator option can be edited independently with its own type and constraints.
+
 #### JSON Validation
 
 Validate any JSON document against your schema with:
@@ -188,7 +194,7 @@ Validate any JSON document against your schema with:
 | `npm run build:dev` | Build with development settings |
 | `npm run lint` | Run linter |
 | `npm run format` | Format code |
-| `npm run check` | Type check the project |
+| `npm run check` | Lint and format check (Biome) |
 | `npm run fix` | Fix linting issues |
 | `npm run typecheck` | Type check with TypeScript |
 | `npm run preview` | Preview production build |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsonjoy-builder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonjoy-builder",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",

--- a/src/components/SchemaEditor/JsonSchemaEditor.tsx
+++ b/src/components/SchemaEditor/JsonSchemaEditor.tsx
@@ -23,6 +23,8 @@ export interface JsonSchemaEditorProps {
   readOnly: boolean;
   setSchema?: (schema: JSONSchema) => void;
   className?: string;
+  /** Whether JSON editor should be focused when mounted. Defaults to `true`. */
+  autoFocus?: boolean;
 }
 
 /** @public */
@@ -31,6 +33,7 @@ const JsonSchemaEditor: FC<JsonSchemaEditorProps> = ({
   readOnly = false,
   setSchema,
   className,
+  autoFocus = true,
 }) => {
   // Handle schema changes and propagate to parent if needed
   const handleSchemaChange = (newSchema: JSONSchema) => {
@@ -137,6 +140,7 @@ const JsonSchemaEditor: FC<JsonSchemaEditorProps> = ({
             <JsonSchemaVisualizer
               schema={schema}
               onChange={handleSchemaChange}
+              autoFocus={autoFocus}
             />
           </TabsContent>
         </Tabs>
@@ -185,6 +189,7 @@ const JsonSchemaEditor: FC<JsonSchemaEditorProps> = ({
             <JsonSchemaVisualizer
               schema={schema}
               onChange={handleSchemaChange}
+              autoFocus={autoFocus}
             />
           </div>
         </div>

--- a/src/components/SchemaEditor/JsonSchemaVisualizer.tsx
+++ b/src/components/SchemaEditor/JsonSchemaVisualizer.tsx
@@ -39,8 +39,7 @@ const JsonSchemaVisualizer: FC<JsonSchemaVisualizerProps> = ({
 
   const handleEditorDidMount: OnMount = (editor) => {
     editorRef.current = editor;
-    if(autoFocus) editor.focus();
-    
+    if (autoFocus) editor.focus();
   };
 
   const handleEditorChange = (value: string | undefined) => {

--- a/src/components/SchemaEditor/JsonSchemaVisualizer.tsx
+++ b/src/components/SchemaEditor/JsonSchemaVisualizer.tsx
@@ -11,6 +11,8 @@ export interface JsonSchemaVisualizerProps {
   schema: JSONSchema;
   className?: string;
   onChange?: (schema: JSONSchema) => void;
+  /** Whether the editor should be focused when mounted. Defaults to `true`. */
+  autoFocus?: boolean;
 }
 
 /** @public */
@@ -18,6 +20,7 @@ const JsonSchemaVisualizer: FC<JsonSchemaVisualizerProps> = ({
   schema,
   className,
   onChange,
+  autoFocus = true,
 }) => {
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const {
@@ -36,7 +39,8 @@ const JsonSchemaVisualizer: FC<JsonSchemaVisualizerProps> = ({
 
   const handleEditorDidMount: OnMount = (editor) => {
     editorRef.current = editor;
-    editor.focus();
+    if(autoFocus) editor.focus();
+    
   };
 
   const handleEditorChange = (value: string | undefined) => {

--- a/src/components/SchemaEditor/SchemaFieldList.tsx
+++ b/src/components/SchemaEditor/SchemaFieldList.tsx
@@ -7,7 +7,11 @@ import type {
   ObjectJSONSchema,
   SchemaType,
 } from "../../types/jsonSchema.ts";
-import { isAllOfSchema, isAnyOfSchema, isOneOfSchema } from "../../types/jsonSchema.ts";
+import {
+  isAllOfSchema,
+  isAnyOfSchema,
+  isOneOfSchema,
+} from "../../types/jsonSchema.ts";
 import { buildValidationTree } from "../../types/validation.ts";
 import SchemaPropertyEditor from "./SchemaPropertyEditor.tsx";
 
@@ -35,7 +39,11 @@ const SchemaFieldList: FC<SchemaFieldListProps> = ({
     if (typeof propSchema === "boolean") return "object";
 
     // combinator schemas don't have a direct type — default to object for NewField purposes
-    if (isAnyOfSchema(propSchema) || isOneOfSchema(propSchema) || isAllOfSchema(propSchema))
+    if (
+      isAnyOfSchema(propSchema) ||
+      isOneOfSchema(propSchema) ||
+      isAllOfSchema(propSchema)
+    )
       return "object";
 
     // Handle array of types by picking the first one
@@ -96,7 +104,11 @@ const SchemaFieldList: FC<SchemaFieldListProps> = ({
     if (!property) return;
 
     // combinator schemas have no direct type field
-    if (isAnyOfSchema(updatedSchema) || isOneOfSchema(updatedSchema) || isAllOfSchema(updatedSchema)) {
+    if (
+      isAnyOfSchema(updatedSchema) ||
+      isOneOfSchema(updatedSchema) ||
+      isAllOfSchema(updatedSchema)
+    ) {
       onEditField(name, {
         name,
         type: "object",

--- a/src/components/SchemaEditor/SchemaFieldList.tsx
+++ b/src/components/SchemaEditor/SchemaFieldList.tsx
@@ -7,6 +7,7 @@ import type {
   ObjectJSONSchema,
   SchemaType,
 } from "../../types/jsonSchema.ts";
+import { isAllOfSchema, isAnyOfSchema, isOneOfSchema } from "../../types/jsonSchema.ts";
 import { buildValidationTree } from "../../types/validation.ts";
 import SchemaPropertyEditor from "./SchemaPropertyEditor.tsx";
 
@@ -32,6 +33,10 @@ const SchemaFieldList: FC<SchemaFieldListProps> = ({
   // Get schema type as a valid SchemaType
   const getValidSchemaType = (propSchema: JSONSchemaType): SchemaType => {
     if (typeof propSchema === "boolean") return "object";
+
+    // combinator schemas don't have a direct type — default to object for NewField purposes
+    if (isAnyOfSchema(propSchema) || isOneOfSchema(propSchema) || isAllOfSchema(propSchema))
+      return "object";
 
     // Handle array of types by picking the first one
     const type = propSchema.type;
@@ -89,6 +94,18 @@ const SchemaFieldList: FC<SchemaFieldListProps> = ({
   ) => {
     const property = properties.find((prop) => prop.name === name);
     if (!property) return;
+
+    // combinator schemas have no direct type field
+    if (isAnyOfSchema(updatedSchema) || isOneOfSchema(updatedSchema) || isAllOfSchema(updatedSchema)) {
+      onEditField(name, {
+        name,
+        type: "object",
+        description: updatedSchema.description || "",
+        required: property.required,
+        validation: updatedSchema,
+      });
+      return;
+    }
 
     const type = updatedSchema.type || "object";
     // Ensure we're using a single type, not an array of types

--- a/src/components/SchemaEditor/SchemaPropertyEditor.tsx
+++ b/src/components/SchemaEditor/SchemaPropertyEditor.tsx
@@ -6,12 +6,12 @@ import { cn } from "../../lib/utils.ts";
 import type {
   JSONSchema,
   ObjectJSONSchema,
-  SchemaType,
+  SchemaEditorType,
 } from "../../types/jsonSchema.ts";
 import {
   asObjectSchema,
+  getEditorType,
   getSchemaDescription,
-  withObjectSchema,
 } from "../../types/jsonSchema.ts";
 import type { ValidationTreeNode } from "../../types/validation.ts";
 import { Badge } from "../ui/badge.tsx";
@@ -49,11 +49,7 @@ export const SchemaPropertyEditor: React.FC<SchemaPropertyEditorProps> = ({
   const [isEditingDesc, setIsEditingDesc] = useState(false);
   const [tempName, setTempName] = useState(name);
   const [tempDesc, setTempDesc] = useState(getSchemaDescription(schema));
-  const type = withObjectSchema(
-    schema,
-    (s) => (s.type || "object") as SchemaType,
-    "object" as SchemaType,
-  );
+  const type = getEditorType(schema);
 
   // Update temp values when props change
   useEffect(() => {
@@ -174,11 +170,24 @@ export const SchemaPropertyEditor: React.FC<SchemaPropertyEditorProps> = ({
               <TypeDropdown
                 value={type}
                 readOnly={readOnly}
-                onChange={(newType) => {
-                  onSchemaChange({
-                    ...asObjectSchema(schema),
-                    type: newType,
-                  });
+                onChange={(newType: SchemaEditorType) => {
+                  if (
+                    newType === "anyOf" ||
+                    newType === "oneOf" ||
+                    newType === "allOf"
+                  ) {
+                    const { type: _type, anyOf: _a, oneOf: _o, allOf: _al, ...rest } =
+                      asObjectSchema(schema);
+                    const initial =
+                      newType === "allOf"
+                        ? { allOf: [{ type: "object" as const }] }
+                        : { [newType]: [{ type: "string" as const }, { type: "number" as const }] };
+                    onSchemaChange({ ...rest, ...initial });
+                  } else {
+                    const { anyOf: _a, oneOf: _o, allOf: _al, ...rest } =
+                      asObjectSchema(schema);
+                    onSchemaChange({ ...rest, type: newType });
+                  }
                 }}
               />
 

--- a/src/components/SchemaEditor/SchemaPropertyEditor.tsx
+++ b/src/components/SchemaEditor/SchemaPropertyEditor.tsx
@@ -176,16 +176,30 @@ export const SchemaPropertyEditor: React.FC<SchemaPropertyEditorProps> = ({
                     newType === "oneOf" ||
                     newType === "allOf"
                   ) {
-                    const { type: _type, anyOf: _a, oneOf: _o, allOf: _al, ...rest } =
-                      asObjectSchema(schema);
+                    const {
+                      type: _type,
+                      anyOf: _a,
+                      oneOf: _o,
+                      allOf: _al,
+                      ...rest
+                    } = asObjectSchema(schema);
                     const initial =
                       newType === "allOf"
                         ? { allOf: [{ type: "object" as const }] }
-                        : { [newType]: [{ type: "string" as const }, { type: "number" as const }] };
+                        : {
+                            [newType]: [
+                              { type: "string" as const },
+                              { type: "number" as const },
+                            ],
+                          };
                     onSchemaChange({ ...rest, ...initial });
                   } else {
-                    const { anyOf: _a, oneOf: _o, allOf: _al, ...rest } =
-                      asObjectSchema(schema);
+                    const {
+                      anyOf: _a,
+                      oneOf: _o,
+                      allOf: _al,
+                      ...rest
+                    } = asObjectSchema(schema);
                     onSchemaChange({ ...rest, type: newType });
                   }
                 }}

--- a/src/components/SchemaEditor/TypeDropdown.tsx
+++ b/src/components/SchemaEditor/TypeDropdown.tsx
@@ -2,22 +2,25 @@ import { Check, ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "../../hooks/use-translation.ts";
 import { cn, getTypeColor, getTypeLabel } from "../../lib/utils.ts";
-import type { SchemaType } from "../../types/jsonSchema.ts";
+import type { SchemaEditorType } from "../../types/jsonSchema.ts";
 
 export interface TypeDropdownProps {
-  value: SchemaType;
-  onChange: (value: SchemaType) => void;
+  value: SchemaEditorType;
+  onChange: (value: SchemaEditorType) => void;
   className?: string;
   readOnly: boolean;
 }
 
-const typeOptions: SchemaType[] = [
+const typeOptions: SchemaEditorType[] = [
   "string",
   "number",
   "boolean",
   "object",
   "array",
   "null",
+  "anyOf",
+  "oneOf",
+  "allOf",
 ];
 
 export const TypeDropdown: React.FC<TypeDropdownProps> = ({

--- a/src/components/SchemaEditor/TypeEditor.tsx
+++ b/src/components/SchemaEditor/TypeEditor.tsx
@@ -1,9 +1,6 @@
 import { lazy, Suspense } from "react";
 import { useTranslation } from "../../hooks/use-translation.ts";
-import type {
-  JSONSchema,
-  ObjectJSONSchema,
-} from "../../types/jsonSchema.ts";
+import type { JSONSchema, ObjectJSONSchema } from "../../types/jsonSchema.ts";
 import { getEditorType } from "../../types/jsonSchema.ts";
 import type { ValidationTreeNode } from "../../types/validation.ts";
 

--- a/src/components/SchemaEditor/TypeEditor.tsx
+++ b/src/components/SchemaEditor/TypeEditor.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from "../../hooks/use-translation.ts";
 import type {
   JSONSchema,
   ObjectJSONSchema,
-  SchemaType,
 } from "../../types/jsonSchema.ts";
-import { withObjectSchema } from "../../types/jsonSchema.ts";
+import { getEditorType } from "../../types/jsonSchema.ts";
 import type { ValidationTreeNode } from "../../types/validation.ts";
 
 // Lazy load specific type editors to avoid circular dependencies
@@ -14,6 +13,7 @@ const NumberEditor = lazy(() => import("./types/NumberEditor.tsx"));
 const BooleanEditor = lazy(() => import("./types/BooleanEditor.tsx"));
 const ObjectEditor = lazy(() => import("./types/ObjectEditor.tsx"));
 const ArrayEditor = lazy(() => import("./types/ArrayEditor.tsx"));
+const CombinatorEditor = lazy(() => import("./types/CombinatorEditor.tsx"));
 
 export interface TypeEditorProps {
   schema: JSONSchema;
@@ -31,11 +31,7 @@ const TypeEditor: React.FC<TypeEditorProps> = ({
   readOnly = false,
 }) => {
   const t = useTranslation();
-  const type = withObjectSchema(
-    schema,
-    (s) => (s.type || "object") as SchemaType,
-    "string" as SchemaType,
-  );
+  const type = getEditorType(schema);
 
   return (
     <Suspense fallback={<div>{t.schemaEditorLoading}</div>}>
@@ -92,6 +88,16 @@ const TypeEditor: React.FC<TypeEditorProps> = ({
           onChange={onChange}
           depth={depth}
           validationNode={validationNode}
+        />
+      )}
+      {(type === "anyOf" || type === "oneOf" || type === "allOf") && (
+        <CombinatorEditor
+          readOnly={readOnly}
+          schema={schema}
+          onChange={onChange}
+          depth={depth}
+          validationNode={validationNode}
+          combinator={type}
         />
       )}
     </Suspense>

--- a/src/components/SchemaEditor/types/AnyOfEditor.tsx
+++ b/src/components/SchemaEditor/types/AnyOfEditor.tsx
@@ -1,0 +1,8 @@
+import type { TypeEditorProps } from "../TypeEditor.tsx";
+import CombinatorEditor from "./CombinatorEditor.tsx";
+
+const AnyOfEditor: React.FC<TypeEditorProps> = (props) => (
+  <CombinatorEditor {...props} combinator="anyOf" />
+);
+
+export default AnyOfEditor;

--- a/src/components/SchemaEditor/types/ArrayEditor.tsx
+++ b/src/components/SchemaEditor/types/ArrayEditor.tsx
@@ -7,9 +7,11 @@ import { getArrayItemsSchema } from "../../../lib/schemaEditor.ts";
 import { cn } from "../../../lib/utils.ts";
 import type {
   ObjectJSONSchema,
+  SchemaEditorType,
   SchemaType,
 } from "../../../types/jsonSchema.ts";
 import {
+  asObjectSchema,
   isBooleanSchema,
   withObjectSchema,
 } from "../../../types/jsonSchema.ts";
@@ -232,11 +234,38 @@ const ArrayEditor: React.FC<TypeEditorProps> = ({
           <TypeDropdown
             readOnly={readOnly}
             value={itemType}
-            onChange={(newType) => {
-              handleItemSchemaChange({
-                ...withObjectSchema(itemsSchema, (s) => s, {}),
-                type: newType,
-              });
+            onChange={(newType: SchemaEditorType) => {
+              if (
+                newType === "anyOf" ||
+                newType === "oneOf" ||
+                newType === "allOf"
+              ) {
+                const {
+                  type: _type,
+                  anyOf: _a,
+                  oneOf: _o,
+                  allOf: _al,
+                  ...rest
+                } = asObjectSchema(itemsSchema);
+                const initial =
+                  newType === "allOf"
+                    ? { allOf: [{ type: "object" as const }] }
+                    : {
+                        [newType]: [
+                          { type: "string" as const },
+                          { type: "number" as const },
+                        ],
+                      };
+                handleItemSchemaChange({ ...rest, ...initial });
+              } else {
+                const {
+                  anyOf: _a,
+                  oneOf: _o,
+                  allOf: _al,
+                  ...rest
+                } = asObjectSchema(itemsSchema);
+                handleItemSchemaChange({ ...rest, type: newType });
+              }
             }}
           />
         </div>

--- a/src/components/SchemaEditor/types/CombinatorEditor.tsx
+++ b/src/components/SchemaEditor/types/CombinatorEditor.tsx
@@ -9,10 +9,7 @@ import type {
   SchemaEditorType,
   SchemaType,
 } from "../../../types/jsonSchema.ts";
-import {
-  getEditorType,
-  isBooleanSchema,
-} from "../../../types/jsonSchema.ts";
+import { getEditorType, isBooleanSchema } from "../../../types/jsonSchema.ts";
 import TypeDropdown from "../TypeDropdown.tsx";
 import type { TypeEditorProps } from "../TypeEditor.tsx";
 import TypeEditor from "../TypeEditor.tsx";
@@ -116,7 +113,8 @@ const CombinatorEditor: React.FC<CombinatorEditorProps> = ({
         [combinator]: _old,
         type: _type,
         ...rest
-      } = base as ObjectJSONSchema & Record<Combinator, JSONSchema[] | undefined>;
+      } = base as ObjectJSONSchema &
+        Record<Combinator, JSONSchema[] | undefined>;
       onChange({ ...rest, [combinator]: newOptions });
     },
     [schema, onChange, combinator],
@@ -136,10 +134,7 @@ const CombinatorEditor: React.FC<CombinatorEditorProps> = ({
     if (expandedId === ids[index]) setExpandedId(null);
   };
 
-  const handleOptionTypeChange = (
-    index: number,
-    newType: SchemaEditorType,
-  ) => {
+  const handleOptionTypeChange = (index: number, newType: SchemaEditorType) => {
     const newOptions = [...options];
     newOptions[index] = DEFAULT_SCHEMAS[newType as SchemaType] ??
       DEFAULT_SCHEMAS[newType as Combinator] ?? { type: "string" };

--- a/src/components/SchemaEditor/types/CombinatorEditor.tsx
+++ b/src/components/SchemaEditor/types/CombinatorEditor.tsx
@@ -1,0 +1,251 @@
+import { CirclePlus, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "../../../hooks/use-translation.ts";
+import type { Translation } from "../../../i18n/translation-keys.ts";
+import { cn } from "../../../lib/utils.ts";
+import type {
+  JSONSchema,
+  ObjectJSONSchema,
+  SchemaEditorType,
+  SchemaType,
+} from "../../../types/jsonSchema.ts";
+import {
+  getEditorType,
+  isBooleanSchema,
+} from "../../../types/jsonSchema.ts";
+import TypeDropdown from "../TypeDropdown.tsx";
+import type { TypeEditorProps } from "../TypeEditor.tsx";
+import TypeEditor from "../TypeEditor.tsx";
+
+export type Combinator = "anyOf" | "oneOf" | "allOf";
+
+interface CombinatorStrings {
+  description: string;
+  addButton: string;
+  removeButton: string;
+  itemLabel: string;
+  noItems: string;
+}
+
+function getCombinatorStrings(
+  t: Translation,
+  combinator: Combinator,
+): CombinatorStrings {
+  switch (combinator) {
+    case "anyOf":
+      return {
+        description: t.anyOfDescription,
+        addButton: t.anyOfAddOption,
+        removeButton: t.anyOfRemoveOption,
+        itemLabel: t.anyOfOptionLabel,
+        noItems: t.anyOfNoOptions,
+      };
+    case "oneOf":
+      return {
+        description: t.oneOfDescription,
+        addButton: t.oneOfAddOption,
+        removeButton: t.oneOfRemoveOption,
+        itemLabel: t.oneOfOptionLabel,
+        noItems: t.oneOfNoOptions,
+      };
+    case "allOf":
+      return {
+        description: t.allOfDescription,
+        addButton: t.allOfAddSchema,
+        removeButton: t.allOfRemoveSchema,
+        itemLabel: t.allOfSchemaLabel,
+        noItems: t.allOfNoSchemas,
+      };
+  }
+}
+
+const DEFAULT_SCHEMAS: Record<SchemaEditorType, ObjectJSONSchema> = {
+  string: { type: "string" },
+  number: { type: "number" },
+  integer: { type: "integer" },
+  boolean: { type: "boolean" },
+  object: { type: "object" },
+  array: { type: "array" },
+  null: { type: "null" },
+  anyOf: { anyOf: [{ type: "string" }, { type: "number" }] },
+  oneOf: { oneOf: [{ type: "string" }, { type: "number" }] },
+  allOf: { allOf: [{ type: "object" }] },
+};
+
+let idCounter = 0;
+const nextId = () => `combinator-${++idCounter}`;
+
+export interface CombinatorEditorProps extends TypeEditorProps {
+  combinator: Combinator;
+}
+
+const CombinatorEditor: React.FC<CombinatorEditorProps> = ({
+  schema,
+  readOnly = false,
+  validationNode,
+  onChange,
+  depth = 0,
+  combinator,
+}) => {
+  const t = useTranslation();
+  const strings = getCombinatorStrings(t, combinator);
+
+  const rawOptions: JSONSchema[] = isBooleanSchema(schema)
+    ? []
+    : (schema[combinator] ?? []);
+
+  // Stable IDs for each option to use as React keys
+  const [ids, setIds] = useState<string[]>(() =>
+    rawOptions.map(() => nextId()),
+  );
+
+  // Keep ids in sync with rawOptions length (e.g. when schema is replaced externally)
+  const options = useMemo(() => {
+    if (rawOptions.length !== ids.length) {
+      setIds(rawOptions.map((_o, i) => ids[i] ?? nextId()));
+    }
+    return rawOptions;
+  }, [rawOptions, ids]);
+
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const updateOptions = useCallback(
+    (newOptions: JSONSchema[]) => {
+      const base = isBooleanSchema(schema) ? {} : schema;
+      const {
+        [combinator]: _old,
+        type: _type,
+        ...rest
+      } = base as ObjectJSONSchema & Record<Combinator, JSONSchema[] | undefined>;
+      onChange({ ...rest, [combinator]: newOptions });
+    },
+    [schema, onChange, combinator],
+  );
+
+  const handleAddOption = () => {
+    const newId = nextId();
+    setIds((prev) => [...prev, newId]);
+    updateOptions([...options, { type: "string" }]);
+    setExpandedId(newId);
+  };
+
+  const handleRemoveOption = (index: number) => {
+    const newOptions = options.filter((_, i) => i !== index);
+    setIds((prev) => prev.filter((_, i) => i !== index));
+    updateOptions(newOptions);
+    if (expandedId === ids[index]) setExpandedId(null);
+  };
+
+  const handleOptionTypeChange = (
+    index: number,
+    newType: SchemaEditorType,
+  ) => {
+    const newOptions = [...options];
+    newOptions[index] = DEFAULT_SCHEMAS[newType as SchemaType] ??
+      DEFAULT_SCHEMAS[newType as Combinator] ?? { type: "string" };
+    updateOptions(newOptions);
+  };
+
+  const handleOptionSchemaChange = (
+    index: number,
+    updatedSchema: ObjectJSONSchema,
+  ) => {
+    const newOptions = [...options];
+    newOptions[index] = updatedSchema;
+    updateOptions(newOptions);
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground italic">
+        {strings.description}
+      </p>
+
+      {options.length === 0 ? (
+        <div className="text-sm text-muted-foreground italic p-2 text-center border rounded-md">
+          {strings.noItems}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {options.map((option, index) => {
+            const id = ids[index];
+            const optionType = getEditorType(option);
+            const isExpanded = expandedId === id;
+
+            return (
+              <div
+                key={id}
+                className={cn(
+                  "rounded-lg border transition-all duration-200",
+                  depth > 0 && "ml-0 sm:ml-4 border-l border-l-border/40",
+                )}
+              >
+                <div className="flex items-center gap-2 px-3 py-2">
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors min-w-[72px] text-left"
+                    onClick={() =>
+                      setExpandedId(isExpanded ? null : (id ?? null))
+                    }
+                  >
+                    {strings.itemLabel} {index + 1}
+                  </button>
+
+                  <div className="flex items-center gap-2 ml-auto">
+                    <TypeDropdown
+                      value={optionType}
+                      readOnly={readOnly}
+                      onChange={(newType) =>
+                        handleOptionTypeChange(index, newType)
+                      }
+                    />
+
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveOption(index)}
+                        className="p-1 rounded-md hover:bg-secondary hover:text-destructive transition-colors text-muted-foreground"
+                        aria-label={strings.removeButton}
+                      >
+                        <X size={14} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {isExpanded && (
+                  <div className="pt-1 pb-2 px-3 border-t animate-in">
+                    <TypeEditor
+                      readOnly={readOnly}
+                      schema={option}
+                      validationNode={
+                        validationNode?.children[`${combinator}:${index}`]
+                      }
+                      onChange={(updatedSchema) =>
+                        handleOptionSchemaChange(index, updatedSchema)
+                      }
+                      depth={depth + 1}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!readOnly && (
+        <button
+          type="button"
+          onClick={handleAddOption}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-secondary"
+        >
+          <CirclePlus size={14} />
+          {strings.addButton}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default CombinatorEditor;

--- a/src/components/features/SchemaInferencer.tsx
+++ b/src/components/features/SchemaInferencer.tsx
@@ -20,6 +20,8 @@ export interface SchemaInferencerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSchemaInferred: (schema: JSONSchema) => void;
+  /** Whether the editor should be focused when mounted. Defaults to `true`. */
+  autoFocus?: boolean;
 }
 
 /** @public */
@@ -27,6 +29,7 @@ export function SchemaInferencer({
   open,
   onOpenChange,
   onSchemaInferred,
+  autoFocus = true,
 }: SchemaInferencerProps) {
   const t = useTranslation();
   const [jsonInput, setJsonInput] = useState("");
@@ -46,7 +49,7 @@ export function SchemaInferencer({
 
   const handleEditorDidMount: OnMount = (editor) => {
     editorRef.current = editor;
-    editor.focus();
+    if (autoFocus) editor.focus();
   };
 
   const handleEditorChange = (value: string | undefined) => {

--- a/src/components/features/SchemaInferencer.tsx
+++ b/src/components/features/SchemaInferencer.tsx
@@ -80,7 +80,12 @@ export function SchemaInferencer({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-4xl max-h-[90vh] flex flex-col jsonjoy">
+      <DialogContent
+        className="sm:max-w-4xl max-h-[90vh] flex flex-col jsonjoy"
+        onOpenAutoFocus={(event) => {
+          if (!autoFocus) event.preventDefault();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{t.inferrerTitle}</DialogTitle>
           <DialogDescription>{t.inferrerDescription}</DialogDescription>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -127,6 +127,27 @@ export const de: Translation = {
   stringValidationErrorLengthRange:
     "'Minimale Länge' darf nicht größer als 'Maximale Länge' sein.",
 
+  schemaTypeAnyOf: "Eines von",
+  anyOfAddOption: "Option hinzufügen",
+  anyOfRemoveOption: "Option entfernen",
+  anyOfOptionLabel: "Option",
+  anyOfDescription: "Der Wert muss mindestens einem dieser Schemata entsprechen",
+  anyOfNoOptions: "Keine Optionen definiert",
+
+  schemaTypeOneOf: "Genau eines von",
+  oneOfAddOption: "Option hinzufügen",
+  oneOfRemoveOption: "Option entfernen",
+  oneOfOptionLabel: "Option",
+  oneOfDescription: "Der Wert muss genau einem dieser Schemata entsprechen",
+  oneOfNoOptions: "Keine Optionen definiert",
+
+  schemaTypeAllOf: "Alle von",
+  allOfAddSchema: "Schema hinzufügen",
+  allOfRemoveSchema: "Schema entfernen",
+  allOfSchemaLabel: "Schema",
+  allOfDescription: "Der Wert muss allen diesen Schemata entsprechen",
+  allOfNoSchemas: "Keine Schemata definiert",
+
   schemaTypeArray: "Liste",
   schemaTypeBoolean: "Ja/Nein",
   schemaTypeNumber: "Zahl",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -131,7 +131,8 @@ export const de: Translation = {
   anyOfAddOption: "Option hinzufügen",
   anyOfRemoveOption: "Option entfernen",
   anyOfOptionLabel: "Option",
-  anyOfDescription: "Der Wert muss mindestens einem dieser Schemata entsprechen",
+  anyOfDescription:
+    "Der Wert muss mindestens einem dieser Schemata entsprechen",
   anyOfNoOptions: "Keine Optionen definiert",
 
   schemaTypeOneOf: "Genau eines von",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -124,6 +124,27 @@ export const en: Translation = {
   stringValidationErrorLengthRange:
     "'Minimum Length' cannot be greater than 'Maximum Length'.",
 
+  schemaTypeAnyOf: "Any Of",
+  anyOfAddOption: "Add Option",
+  anyOfRemoveOption: "Remove option",
+  anyOfOptionLabel: "Option",
+  anyOfDescription: "Value must match at least one of these schemas",
+  anyOfNoOptions: "No options defined",
+
+  schemaTypeOneOf: "One Of",
+  oneOfAddOption: "Add Option",
+  oneOfRemoveOption: "Remove option",
+  oneOfOptionLabel: "Option",
+  oneOfDescription: "Value must match exactly one of these schemas",
+  oneOfNoOptions: "No options defined",
+
+  schemaTypeAllOf: "All Of",
+  allOfAddSchema: "Add Schema",
+  allOfRemoveSchema: "Remove schema",
+  allOfSchemaLabel: "Schema",
+  allOfDescription: "Value must match all of these schemas",
+  allOfNoSchemas: "No schemas defined",
+
   schemaTypeArray: "List",
   schemaTypeBoolean: "Yes/No",
   schemaTypeNumber: "Number",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -126,6 +126,27 @@ export const es: Translation = {
   stringValidationErrorLengthRange:
     "'Longitud Mínima' no puede ser mayor que 'Longitud Máxima'.",
 
+  schemaTypeAnyOf: "Cualquiera de",
+  anyOfAddOption: "Agregar opción",
+  anyOfRemoveOption: "Eliminar opción",
+  anyOfOptionLabel: "Opción",
+  anyOfDescription: "El valor debe coincidir con al menos uno de estos esquemas",
+  anyOfNoOptions: "No hay opciones definidas",
+
+  schemaTypeOneOf: "Exactamente uno de",
+  oneOfAddOption: "Agregar opción",
+  oneOfRemoveOption: "Eliminar opción",
+  oneOfOptionLabel: "Opción",
+  oneOfDescription: "El valor debe coincidir con exactamente uno de estos esquemas",
+  oneOfNoOptions: "No hay opciones definidas",
+
+  schemaTypeAllOf: "Todos de",
+  allOfAddSchema: "Agregar esquema",
+  allOfRemoveSchema: "Eliminar esquema",
+  allOfSchemaLabel: "Esquema",
+  allOfDescription: "El valor debe coincidir con todos estos esquemas",
+  allOfNoSchemas: "No hay esquemas definidos",
+
   schemaTypeArray: "Lista",
   schemaTypeBoolean: "Sí/No",
   schemaTypeNumber: "Número",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -130,14 +130,16 @@ export const es: Translation = {
   anyOfAddOption: "Agregar opción",
   anyOfRemoveOption: "Eliminar opción",
   anyOfOptionLabel: "Opción",
-  anyOfDescription: "El valor debe coincidir con al menos uno de estos esquemas",
+  anyOfDescription:
+    "El valor debe coincidir con al menos uno de estos esquemas",
   anyOfNoOptions: "No hay opciones definidas",
 
   schemaTypeOneOf: "Exactamente uno de",
   oneOfAddOption: "Agregar opción",
   oneOfRemoveOption: "Eliminar opción",
   oneOfOptionLabel: "Opción",
-  oneOfDescription: "El valor debe coincidir con exactamente uno de estos esquemas",
+  oneOfDescription:
+    "El valor debe coincidir con exactamente uno de estos esquemas",
   oneOfNoOptions: "No hay opciones definidas",
 
   schemaTypeAllOf: "Todos de",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -139,7 +139,8 @@ export const fr: Translation = {
   oneOfAddOption: "Ajouter une option",
   oneOfRemoveOption: "Supprimer l'option",
   oneOfOptionLabel: "Option",
-  oneOfDescription: "La valeur doit correspondre à exactement un de ces schémas",
+  oneOfDescription:
+    "La valeur doit correspondre à exactement un de ces schémas",
   oneOfNoOptions: "Aucune option définie",
 
   schemaTypeAllOf: "Tous de",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -128,6 +128,27 @@ export const fr: Translation = {
   stringValidationErrorLengthRange:
     "'Longueur minimale' ne peut pas être supérieure à 'Longueur maximale'.",
 
+  schemaTypeAnyOf: "L'un de",
+  anyOfAddOption: "Ajouter une option",
+  anyOfRemoveOption: "Supprimer l'option",
+  anyOfOptionLabel: "Option",
+  anyOfDescription: "La valeur doit correspondre à au moins un de ces schémas",
+  anyOfNoOptions: "Aucune option définie",
+
+  schemaTypeOneOf: "Exactement l'un de",
+  oneOfAddOption: "Ajouter une option",
+  oneOfRemoveOption: "Supprimer l'option",
+  oneOfOptionLabel: "Option",
+  oneOfDescription: "La valeur doit correspondre à exactement un de ces schémas",
+  oneOfNoOptions: "Aucune option définie",
+
+  schemaTypeAllOf: "Tous de",
+  allOfAddSchema: "Ajouter un schéma",
+  allOfRemoveSchema: "Supprimer le schéma",
+  allOfSchemaLabel: "Schéma",
+  allOfDescription: "La valeur doit correspondre à tous ces schémas",
+  allOfNoSchemas: "Aucun schéma défini",
+
   schemaTypeArray: "Liste",
   schemaTypeBoolean: "Oui/Non",
   schemaTypeNumber: "Nombre",

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -130,14 +130,16 @@ export const pl: Translation = {
   anyOfAddOption: "Dodaj opcję",
   anyOfRemoveOption: "Usuń opcję",
   anyOfOptionLabel: "Opcja",
-  anyOfDescription: "Wartość musi pasować do co najmniej jednego z tych schematów",
+  anyOfDescription:
+    "Wartość musi pasować do co najmniej jednego z tych schematów",
   anyOfNoOptions: "Nie zdefiniowano opcji",
 
   schemaTypeOneOf: "Dokładnie jeden z",
   oneOfAddOption: "Dodaj opcję",
   oneOfRemoveOption: "Usuń opcję",
   oneOfOptionLabel: "Opcja",
-  oneOfDescription: "Wartość musi pasować do dokładnie jednego z tych schematów",
+  oneOfDescription:
+    "Wartość musi pasować do dokładnie jednego z tych schematów",
   oneOfNoOptions: "Nie zdefiniowano opcji",
 
   schemaTypeAllOf: "Wszystkie z",

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -126,6 +126,27 @@ export const pl: Translation = {
   stringValidationErrorLengthRange:
     "'Minimalna długość' nie może być większa niż 'Maksymalna długość'.",
 
+  schemaTypeAnyOf: "Jeden z",
+  anyOfAddOption: "Dodaj opcję",
+  anyOfRemoveOption: "Usuń opcję",
+  anyOfOptionLabel: "Opcja",
+  anyOfDescription: "Wartość musi pasować do co najmniej jednego z tych schematów",
+  anyOfNoOptions: "Nie zdefiniowano opcji",
+
+  schemaTypeOneOf: "Dokładnie jeden z",
+  oneOfAddOption: "Dodaj opcję",
+  oneOfRemoveOption: "Usuń opcję",
+  oneOfOptionLabel: "Opcja",
+  oneOfDescription: "Wartość musi pasować do dokładnie jednego z tych schematów",
+  oneOfNoOptions: "Nie zdefiniowano opcji",
+
+  schemaTypeAllOf: "Wszystkie z",
+  allOfAddSchema: "Dodaj schemat",
+  allOfRemoveSchema: "Usuń schemat",
+  allOfSchemaLabel: "Schemat",
+  allOfDescription: "Wartość musi pasować do wszystkich tych schematów",
+  allOfNoSchemas: "Nie zdefiniowano schematów",
+
   schemaTypeArray: "Lista",
   schemaTypeBoolean: "Tak/Nie",
   schemaTypeNumber: "Liczba",

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -131,7 +131,8 @@ export const ru: Translation = {
   anyOfAddOption: "Добавить вариант",
   anyOfRemoveOption: "Удалить вариант",
   anyOfOptionLabel: "Вариант",
-  anyOfDescription: "Значение должно соответствовать хотя бы одной из этих схем",
+  anyOfDescription:
+    "Значение должно соответствовать хотя бы одной из этих схем",
   anyOfNoOptions: "Варианты не определены",
 
   schemaTypeOneOf: "Ровно одно из",

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -127,6 +127,27 @@ export const ru: Translation = {
   stringValidationErrorLengthRange:
     "'Минимальная длина' не может быть больше 'Максимальной длины'.",
 
+  schemaTypeAnyOf: "Одно из",
+  anyOfAddOption: "Добавить вариант",
+  anyOfRemoveOption: "Удалить вариант",
+  anyOfOptionLabel: "Вариант",
+  anyOfDescription: "Значение должно соответствовать хотя бы одной из этих схем",
+  anyOfNoOptions: "Варианты не определены",
+
+  schemaTypeOneOf: "Ровно одно из",
+  oneOfAddOption: "Добавить вариант",
+  oneOfRemoveOption: "Удалить вариант",
+  oneOfOptionLabel: "Вариант",
+  oneOfDescription: "Значение должно соответствовать ровно одной из этих схем",
+  oneOfNoOptions: "Варианты не определены",
+
+  schemaTypeAllOf: "Все из",
+  allOfAddSchema: "Добавить схему",
+  allOfRemoveSchema: "Удалить схему",
+  allOfSchemaLabel: "Схема",
+  allOfDescription: "Значение должно соответствовать всем этим схемам",
+  allOfNoSchemas: "Схемы не определены",
+
   schemaTypeArray: "Список",
   schemaTypeBoolean: "Да/Нет",
   schemaTypeNumber: "Число",

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -126,6 +126,27 @@ export const uk: Translation = {
   stringValidationErrorLengthRange:
     "'Мінімальна довжина' не може бути більшою за 'Максимальну довжину'.",
 
+  schemaTypeAnyOf: "Одне з",
+  anyOfAddOption: "Додати варіант",
+  anyOfRemoveOption: "Видалити варіант",
+  anyOfOptionLabel: "Варіант",
+  anyOfDescription: "Значення має відповідати хоча б одній з цих схем",
+  anyOfNoOptions: "Варіанти не визначені",
+
+  schemaTypeOneOf: "Рівно одне з",
+  oneOfAddOption: "Додати варіант",
+  oneOfRemoveOption: "Видалити варіант",
+  oneOfOptionLabel: "Варіант",
+  oneOfDescription: "Значення має відповідати рівно одній з цих схем",
+  oneOfNoOptions: "Варіанти не визначені",
+
+  schemaTypeAllOf: "Усі з",
+  allOfAddSchema: "Додати схему",
+  allOfRemoveSchema: "Видалити схему",
+  allOfSchemaLabel: "Схема",
+  allOfDescription: "Значення має відповідати всім цим схемам",
+  allOfNoSchemas: "Схеми не визначені",
+
   schemaTypeArray: "Список",
   schemaTypeBoolean: "Так/Ні",
   schemaTypeNumber: "Число",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -121,6 +121,27 @@ export const zh: Translation = {
   stringFormatSelectPlaceholder: "选择格式",
   stringValidationErrorLengthRange: "「最小长度」不能大于「最大长度」",
 
+  schemaTypeAnyOf: "任意一个",
+  anyOfAddOption: "添加选项",
+  anyOfRemoveOption: "删除选项",
+  anyOfOptionLabel: "选项",
+  anyOfDescription: "值必须符合至少一个以下 Schema",
+  anyOfNoOptions: "未定义选项",
+
+  schemaTypeOneOf: "恰好一个",
+  oneOfAddOption: "添加选项",
+  oneOfRemoveOption: "删除选项",
+  oneOfOptionLabel: "选项",
+  oneOfDescription: "值必须恰好符合一个以下 Schema",
+  oneOfNoOptions: "未定义选项",
+
+  schemaTypeAllOf: "全部",
+  allOfAddSchema: "添加 Schema",
+  allOfRemoveSchema: "删除 Schema",
+  allOfSchemaLabel: "Schema",
+  allOfDescription: "值必须符合所有以下 Schema",
+  allOfNoSchemas: "未定义 Schema",
+
   schemaTypeArray: "数组",
   schemaTypeBoolean: "布尔值",
   schemaTypeNumber: "数字",

--- a/src/i18n/translation-keys.ts
+++ b/src/i18n/translation-keys.ts
@@ -611,6 +611,117 @@ export interface Translation {
   readonly stringValidationErrorLengthRange: string;
 
   /**
+   * The translation for the key `schemaTypeAnyOf`. English default is:
+   *
+   * > Any Of
+   */
+  readonly schemaTypeAnyOf: string;
+  /**
+   * The translation for the key `anyOfAddOption`. English default is:
+   *
+   * > Add Option
+   */
+  readonly anyOfAddOption: string;
+  /**
+   * The translation for the key `anyOfRemoveOption`. English default is:
+   *
+   * > Remove option
+   */
+  readonly anyOfRemoveOption: string;
+  /**
+   * The translation for the key `anyOfOptionLabel`. English default is:
+   *
+   * > Option
+   */
+  readonly anyOfOptionLabel: string;
+  /**
+   * The translation for the key `anyOfDescription`. English default is:
+   *
+   * > Value must match at least one of these schemas
+   */
+  readonly anyOfDescription: string;
+  /**
+   * The translation for the key `anyOfNoOptions`. English default is:
+   *
+   * > No options defined
+   */
+  readonly anyOfNoOptions: string;
+
+  /**
+   * The translation for the key `schemaTypeOneOf`. English default is:
+   *
+   * > One Of
+   */
+  readonly schemaTypeOneOf: string;
+  /**
+   * The translation for the key `oneOfAddOption`. English default is:
+   *
+   * > Add Option
+   */
+  readonly oneOfAddOption: string;
+  /**
+   * The translation for the key `oneOfRemoveOption`. English default is:
+   *
+   * > Remove option
+   */
+  readonly oneOfRemoveOption: string;
+  /**
+   * The translation for the key `oneOfOptionLabel`. English default is:
+   *
+   * > Option
+   */
+  readonly oneOfOptionLabel: string;
+  /**
+   * The translation for the key `oneOfDescription`. English default is:
+   *
+   * > Value must match exactly one of these schemas
+   */
+  readonly oneOfDescription: string;
+  /**
+   * The translation for the key `oneOfNoOptions`. English default is:
+   *
+   * > No options defined
+   */
+  readonly oneOfNoOptions: string;
+
+  /**
+   * The translation for the key `schemaTypeAllOf`. English default is:
+   *
+   * > All Of
+   */
+  readonly schemaTypeAllOf: string;
+  /**
+   * The translation for the key `allOfAddSchema`. English default is:
+   *
+   * > Add Schema
+   */
+  readonly allOfAddSchema: string;
+  /**
+   * The translation for the key `allOfRemoveSchema`. English default is:
+   *
+   * > Remove schema
+   */
+  readonly allOfRemoveSchema: string;
+  /**
+   * The translation for the key `allOfSchemaLabel`. English default is:
+   *
+   * > Schema
+   */
+  readonly allOfSchemaLabel: string;
+  /**
+   * The translation for the key `allOfDescription`. English default is:
+   *
+   * > Value must match all of these schemas
+   */
+  readonly allOfDescription: string;
+  /**
+   * The translation for the key `allOfNoSchemas`. English default is:
+   *
+   * > No schemas defined
+   */
+  readonly allOfNoSchemas: string;
+
+  /**
    * The translation for the key `schemaTypeString`. English default is:
    *
    * > Text

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,7 +33,10 @@ export const getTypeColor = (type: SchemaEditorType): string => {
 };
 
 // Get type display label
-export const getTypeLabel = (t: Translation, type: SchemaEditorType): string => {
+export const getTypeLabel = (
+  t: Translation,
+  type: SchemaEditorType,
+): string => {
   switch (type) {
     case "string":
       return t.schemaTypeString;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,14 +1,14 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import type { Translation } from "../i18n/translation-keys.ts";
-import type { SchemaType } from "../types/jsonSchema.ts";
+import type { SchemaEditorType } from "../types/jsonSchema.ts";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
 // Helper functions for backward compatibility
-export const getTypeColor = (type: SchemaType): string => {
+export const getTypeColor = (type: SchemaEditorType): string => {
   switch (type) {
     case "string":
       return "text-blue-500 bg-blue-50";
@@ -23,11 +23,17 @@ export const getTypeColor = (type: SchemaType): string => {
       return "text-pink-500 bg-pink-50";
     case "null":
       return "text-gray-500 bg-gray-50";
+    case "anyOf":
+      return "text-teal-500 bg-teal-50";
+    case "oneOf":
+      return "text-cyan-500 bg-cyan-50";
+    case "allOf":
+      return "text-indigo-500 bg-indigo-50";
   }
 };
 
 // Get type display label
-export const getTypeLabel = (t: Translation, type: SchemaType): string => {
+export const getTypeLabel = (t: Translation, type: SchemaEditorType): string => {
   switch (type) {
     case "string":
       return t.schemaTypeString;
@@ -42,5 +48,11 @@ export const getTypeLabel = (t: Translation, type: SchemaType): string => {
       return t.schemaTypeArray;
     case "null":
       return t.schemaTypeNull;
+    case "anyOf":
+      return t.schemaTypeAnyOf;
+    case "oneOf":
+      return t.schemaTypeOneOf;
+    case "allOf":
+      return t.schemaTypeAllOf;
   }
 };

--- a/src/types/jsonSchema.ts
+++ b/src/types/jsonSchema.ts
@@ -152,6 +152,9 @@ export interface SchemaEditorState {
 
 export type ObjectJSONSchema = Exclude<JSONSchema, boolean>;
 
+/** Virtual type used in the editor UI to represent combinator schemas */
+export type SchemaEditorType = SchemaType | "anyOf" | "oneOf" | "allOf";
+
 export function isBooleanSchema(schema: JSONSchema): schema is boolean {
   return typeof schema === "boolean";
 }
@@ -173,4 +176,27 @@ export function withObjectSchema<T>(
   defaultValue: T,
 ): T {
   return isObjectSchema(schema) ? fn(schema) : defaultValue;
+}
+
+export function isAnyOfSchema(schema: JSONSchema): boolean {
+  return isObjectSchema(schema) && Array.isArray(schema.anyOf);
+}
+
+export function isOneOfSchema(schema: JSONSchema): boolean {
+  return isObjectSchema(schema) && Array.isArray(schema.oneOf);
+}
+
+export function isAllOfSchema(schema: JSONSchema): boolean {
+  return isObjectSchema(schema) && Array.isArray(schema.allOf);
+}
+
+export function getEditorType(schema: JSONSchema): SchemaEditorType {
+  if (isAnyOfSchema(schema)) return "anyOf";
+  if (isOneOfSchema(schema)) return "oneOf";
+  if (isAllOfSchema(schema)) return "allOf";
+  return withObjectSchema(
+    schema,
+    (s) => (s.type || "object") as SchemaType,
+    "object" as SchemaType,
+  );
 }


### PR DESCRIPTION
This branch base from PR #38 
- Added optional `autoFocus` prop (`boolean`, default `true`) to `JsonSchemaVisualizer` and `SchemaInferencer`
- When `false`, the Monaco editor will not steal focus on mount — useful when embedding these components in complex layouts where focus management is handled externally